### PR TITLE
Works with bash < 4.3

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -6,6 +6,9 @@
 # Usage: stack_new name
 #
 # Example: stack_new x
+
+# Edited in order to work with bash < 4.3
+
 function stack_new
 {
     : ${1?'Missing stack name'}
@@ -15,9 +18,8 @@ function stack_new
         return 1
     fi
 
-    eval "declare -ag _stack_$1"
-    eval "declare -ig _stack_$1_i"
-    eval "let _stack_$1_i=0"
+    eval "_stack_$1=()"
+    eval "_stack_$1_i=0"
     return 0
 }
 


### PR DESCRIPTION
=> declare -g doesn't work in bash 4.1, but this change should still maintain compatibility with bash > 4.1
